### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,10 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,15 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def update
+    item = Item.find(params[:id])
+    if item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,9 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+    unless current_user.id == @item.user_id
+      redirect_to root_path
+    end
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,9 +24,7 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
-    unless current_user.id == @item.user_id
-      redirect_to root_path
-    end
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def update

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,11 +30,10 @@ class ItemsController < ApplicationController
   end
 
   def update
-    item = Item.find(params[:id])
-    if item.update(item_params)
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
       redirect_to root_path
     else
-      @item = Item.find(params[:id])
       render :edit
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,6 +31,7 @@ class ItemsController < ApplicationController
     if item.update(item_params)
       redirect_to root_path
     else
+      @item = Item.find(params[:id])
       render :edit
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :new_item, only: [:show, :edit, :update]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -19,16 +20,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to root_path
     else
@@ -42,4 +40,9 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:item_name, :price, :item_category_id, :item_status_id, :fee_resp_id, :prefecture_id,
                                  :delivery_term_id, :content, :image).merge(user_id: current_user.id)
   end
+
+  def new_item
+    @item = Item.find(params[:id])
+  end
+
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,4 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
+<%# cssは商品出品のものを併用しています。app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
@@ -7,145 +6,145 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url:item_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%# render 'shared/error_messages', model: f.object %>
+      <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
-    <%# 商品画像 %>
-    <div class="img-upload">
-      <div class="weight-bold-text">
-        商品画像
-        <span class="indispensable">必須</span>
-      </div>
-      <div class="click-upload">
-        <p>
-          クリックしてファイルをアップロード
-        </p>
-        <%= f.file_field :hoge, id:"item-image" %>
-      </div>
-    </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
-    <div class="new-items">
-      <div class="weight-bold-text">
-        商品名
-        <span class="indispensable">必須</span>
-      </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
-      <div class="items-explain">
+      <%# 商品画像 %>
+      <div class="img-upload">
         <div class="weight-bold-text">
-          商品の説明
+          商品画像
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <div class="click-upload">
+          <p>
+            クリックしてファイルをアップロード
+          </p>
+          <%= f.file_field :image, id:"item-image" %>
+        </div>
       </div>
-    </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
-    <div class="items-detail">
-      <div class="weight-bold-text">商品の詳細</div>
-      <div class="form">
+      <%# /商品画像 %>
+      <%# 商品名と商品説明 %>
+      <div class="new-items">
         <div class="weight-bold-text">
-          カテゴリー
+          商品名
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
-        <div class="weight-bold-text">
-          商品の状態
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
-      </div>
-    </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
-    <div class="items-detail">
-      <div class="weight-bold-text question-text">
-        <span>配送について</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div class="form">
-        <div class="weight-bold-text">
-          配送料の負担
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
-        <div class="weight-bold-text">
-          発送元の地域
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
-          発送までの日数
-          <span class="indispensable">必須</span>
-        </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
-      </div>
-    </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
-    <div class="sell-price">
-      <div class="weight-bold-text question-text">
-        <span>販売価格<br>(¥300〜9,999,999)</span>
-        <a class="question" href="#">?</a>
-      </div>
-      <div>
-        <div class="price-content">
-          <div class="price-text">
-            <span>価格</span>
+        <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+        <div class="items-explain">
+          <div class="weight-bold-text">
+            商品の説明
             <span class="indispensable">必須</span>
           </div>
-          <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
-        </div>
-        <div class="price-content">
-          <span>販売手数料 (10%)</span>
-          <span>
-            <span id='add-tax-price'></span>円
-          </span>
-        </div>
-        <div class="price-content">
-          <span>販売利益</span>
-          <span>
-            <span id='profit'></span>円
-          </span>
+          <%= f.text_area :content, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
         </div>
       </div>
-    </div>
-    <%# /販売価格 %>
+      <%# /商品名と商品説明 %>
 
-    <%# 注意書き %>
-    <div class="caution">
-      <p class="sentence">
-        <a href="#">禁止されている出品、</a>
-        <a href="#">行為</a>
-        を必ずご確認ください。
-      </p>
-      <p class="sentence">
-        またブランド品でシリアルナンバー等がある場合はご記載ください。
-        <a href="#">偽ブランドの販売</a>
-        は犯罪であり処罰される可能性があります。
-      </p>
-      <p class="sentence">
-        また、出品をもちまして
-        <a href="#">加盟店規約</a>
-        に同意したことになります。
-      </p>
-    </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
-    <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
-    </div>
-    <%# /下部ボタン %>
-  </div>
+      <%# 商品の詳細 %>
+      <div class="items-detail">
+        <div class="weight-bold-text">商品の詳細</div>
+        <div class="form">
+          <div class="weight-bold-text">
+            カテゴリー
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:item_category_id, ItemCategory.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+          <div class="weight-bold-text">
+            商品の状態
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:item_status_id, ItemStatus.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        </div>
+      </div>
+      <%# /商品の詳細 %>
+
+      <%# 配送について %>
+      <div class="items-detail">
+        <div class="weight-bold-text question-text">
+          <span>配送について</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div class="form">
+          <div class="weight-bold-text">
+            配送料の負担
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:fee_resp_id, FeeResp.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+          <div class="weight-bold-text">
+            発送元の地域
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+          <div class="weight-bold-text">
+            発送までの日数
+            <span class="indispensable">必須</span>
+          </div>
+          <%= f.collection_select(:delivery_term_id, DeliveryTerm.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        </div>
+      </div>
+      <%# /配送について %>
+
+      <%# 販売価格 %>
+      <div class="sell-price">
+        <div class="weight-bold-text question-text">
+          <span>販売価格<br>(¥300〜9,999,999)</span>
+          <a class="question" href="#">?</a>
+        </div>
+        <div>
+          <div class="price-content">
+            <div class="price-text">
+              <span>価格</span>
+              <span class="indispensable">必須</span>
+            </div>
+            <span class="sell-yen">¥</span>
+            <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          </div>
+          <div class="price-content">
+            <span>販売手数料 (10%)</span>
+            <span>
+              <span id='add-tax-price'></span>円
+            </span>
+          </div>
+          <div class="price-content">
+            <span>販売利益</span>
+            <span>
+              <span id='profit'></span>円
+            </span>
+          </div>
+        </div>
+      </div>
+      <%# /販売価格 %>
+
+      <%# 注意書き %>
+      <div class="caution">
+        <p class="sentence">
+          <a href="#">禁止されている出品、</a>
+          <a href="#">行為</a>
+          を必ずご確認ください。
+        </p>
+        <p class="sentence">
+          またブランド品でシリアルナンバー等がある場合はご記載ください。
+          <a href="#">偽ブランドの販売</a>
+          は犯罪であり処罰される可能性があります。
+        </p>
+        <p class="sentence">
+          また、出品をもちまして
+          <a href="#">加盟店規約</a>
+          に同意したことになります。
+        </p>
+      </div>
+      <%# /注意書き %>
+      <%# 下部ボタン %>
+      <div class="sell-btn-contents">
+        <%= f.submit "変更する" ,class:"sell-btn" %>
+        <%=link_to 'もどる', "#", class:"back-btn" %>
+      </div>
+      <%# /下部ボタン %>
   <% end %>
+  </div>
 
   <footer class="items-sell-footer">
     <ul class="menu">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,9 +8,7 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url:item_path, local: true do |f| %>
 
-      <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-      <%# render 'shared/error_messages', model: f.object %>
-      <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+      <%= render 'shared/error_messages', model: f.object %>
 
       <%# 商品画像 %>
       <div class="img-upload">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
     <% if user_signed_in? %>
       <%# 出品ユーザーが同一人物である場合 %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to:'items#index'
-  resources :items, only: [:index, :new, :edit, :show, :create]
+  resources :items, only: [:index, :new, :edit, :show, :create, :update]
 end


### PR DESCRIPTION
# what
* 商品情報の編集機能を実装

# why
* 出品商品の詳細情報を編集可能にすることで、ユーザーの利便性を高める為。

# gyazo
- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
 https://gyazo.com/364d51ca0736ccccfe4db5b0240902be
- 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
 https://gyazo.com/28edd8cd35c015095f83f4fdd6d58d53
- 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
 https://gyazo.com/3f5e3d5989e9ec564f5cd476d2482088
- 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
 https://gyazo.com/539089972019a2f7435bc09444f1e2a4
- ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
 https://gyazo.com/bdcadbddbb826551076f84a4f9b6b963
- ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
 -> 商品購入機能実装前のため、対応なし
- ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
 https://gyazo.com/243a3a9a17c69b6ffe3894d04441830d
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
  https://gyazo.com/364d51ca0736ccccfe4db5b0240902be
