### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,6 +33,15 @@ class ItemsController < ApplicationController
       render :edit
     end
   end
+  def destroy
+    @item = Item.find(params[:id])
+    if user_signed_in? && ( current_user.id == @item.user_id )
+      @item.destroy
+      redirect_to root_path
+    else
+      render :show
+    end
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :new_item, only: [:show, :edit, :update]
+  before_action :new_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :destroy]
 
   def index
     @items = Item.all.order('created_at DESC')
@@ -23,7 +24,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    redirect_to root_path unless current_user.id == @item.user_id
   end
 
   def update
@@ -34,13 +34,7 @@ class ItemsController < ApplicationController
     end
   end
   def destroy
-    @item = Item.find(params[:id])
-    if user_signed_in? && ( current_user.id == @item.user_id )
-      @item.destroy
-      redirect_to root_path
-    else
-      render :show
-    end
+    @item.destroy
   end
 
   private
@@ -52,6 +46,10 @@ class ItemsController < ApplicationController
 
   def new_item
     @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -32,7 +32,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
       <%# 出品ユーザーが同一人物でない場合 %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to:'items#index'
-  resources :items, only: [:index, :new, :edit, :show, :create, :update]
+  resources :items
 end


### PR DESCRIPTION
# what
* 商品情報の削除機能を実装

# why
* 必要なくなった商品を削除可能にすることで、ユーザーの利便性を高める為。

# gyazo
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
 https://gyazo.com/fac02013125b74e4b4b27f38d51aae93
